### PR TITLE
rest-client_version

### DIFF
--- a/pingdom-cli.gemspec
+++ b/pingdom-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'thor', '~> 0.19.1'
-  gem.add_dependency 'rest-client'
+  gem.add_dependency 'rest-client', '~>1.8.0'
 
   gem.add_development_dependency 'bundler', '~> 1.7.2'
   gem.add_development_dependency 'pry', '~> 0.10.1'


### PR DESCRIPTION
The rest-client gem depends on mime-types and that had an upgrade which requires ruby 2

By pinning rest-client to an older version then we can install on ruby 1.9
